### PR TITLE
feat: Wave 2 - CLI Build Command Push to Storage

### DIFF
--- a/packages/squizzle-cli/README.md
+++ b/packages/squizzle-cli/README.md
@@ -29,7 +29,7 @@ Creates:
 
 ### `squizzle build <version>`
 
-Build a new migration version:
+Build a new migration version and push to storage:
 
 ```bash
 squizzle build 1.0.0 --notes "Add user authentication"
@@ -39,12 +39,44 @@ squizzle build 1.0.0 --notes "Add user authentication"
 #   -a, --author <author>   Version author
 #   -t, --tag <tags...>     Version tags
 #   --dry-run              Simulate build without creating artifacts
+#   --registry <registry>   Override OCI registry URL
+#   --repository <repo>     Override OCI repository name
+#   --skip-push            Skip pushing to storage (local build only)
 ```
 
-Bundles:
-- Drizzle migrations from `db/drizzle/`
-- Custom SQL from `db/custom/`
+Features:
+- Bundles Drizzle migrations from `db/drizzle/`
+- Includes custom SQL from `db/custom/`
 - Creates immutable tarball with manifest
+- Pushes to configured OCI registry
+- Verifies successful upload
+- Reports upload speed and size
+
+#### Storage Configuration
+
+The build command supports flexible storage configuration with precedence:
+
+1. **CLI options** (`--registry`, `--repository`) - Highest priority
+2. **Environment variables** (`SQUIZZLE_REGISTRY`, `SQUIZZLE_REPOSITORY`)
+3. **Config file** (`.squizzle.yaml`) - Default
+
+Examples:
+
+```bash
+# Use config file settings
+squizzle build 1.0.0
+
+# Override registry via CLI
+squizzle build 1.0.0 --registry docker.io --repository myorg/myapp
+
+# Override via environment variables
+export SQUIZZLE_REGISTRY=ghcr.io
+export SQUIZZLE_REPOSITORY=myorg/myapp
+squizzle build 1.0.0
+
+# Build locally without pushing
+squizzle build 1.0.0 --skip-push
+```
 
 ### `squizzle apply <version>`
 
@@ -147,6 +179,8 @@ custom:
 - `DATABASE_URL` - Database connection string
 - `SQUIZZLE_ENV` - Default environment (overrides -e flag)
 - `SQUIZZLE_CONFIG` - Config file path (overrides -c flag)
+- `SQUIZZLE_REGISTRY` - Override OCI registry URL for storage
+- `SQUIZZLE_REPOSITORY` - Override OCI repository name for storage
 - `NO_COLOR` - Disable colored output
 - `CI` - Enable CI mode (no interactive prompts)
 
@@ -224,6 +258,54 @@ deploy:
     - squizzle apply $CI_COMMIT_SHA --env production
   environment:
     name: production
+```
+
+## Testing
+
+### Unit Tests
+
+Run unit tests for CLI commands:
+
+```bash
+npm test
+```
+
+### Integration Tests
+
+Integration tests require a real OCI registry to test push functionality:
+
+```bash
+# Set test registry credentials
+export SQUIZZLE_TEST_REGISTRY=ghcr.io
+export SQUIZZLE_TEST_REPOSITORY=your-org/squizzle-test
+
+# Login to registry
+docker login ghcr.io
+
+# Run integration tests
+npm test -- build.integration.test.ts
+```
+
+Integration tests will:
+- Create temporary test versions (99.99.x)
+- Push artifacts to the configured test registry
+- Verify push, retrieval, and deletion operations
+- Clean up test artifacts after completion
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Build TypeScript
+npm run build
+
+# Run in development mode
+npm run dev -- <command>
+
+# Run tests
+npm test
 ```
 
 ## License

--- a/packages/squizzle-cli/src/cli.ts
+++ b/packages/squizzle-cli/src/cli.ts
@@ -50,6 +50,9 @@ program
   .option('-a, --author <author>', 'version author')
   .option('-t, --tag <tags...>', 'version tags')
   .option('--dry-run', 'simulate build without creating artifacts')
+  .option('--registry <registry>', 'override OCI registry URL')
+  .option('--repository <repository>', 'override OCI repository name')
+  .option('--skip-push', 'skip pushing to storage (local build only)')
   .action(async (version, options) => {
     const config = await loadConfig(program.opts().config)
     await buildCommand(version, { ...options, config })

--- a/packages/squizzle-cli/src/commands/build.integration.test.ts
+++ b/packages/squizzle-cli/src/commands/build.integration.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { buildCommand } from './build'
+import { createOCIStorage } from '@squizzle/oci'
+import { Config } from '../config'
+import * as fs from 'fs/promises'
+import * as path from 'path'
+import { tmpdir } from 'os'
+import { execSync } from 'child_process'
+
+// Integration tests with real registry
+// Requires:
+// - SQUIZZLE_TEST_REGISTRY env var (e.g., ghcr.io)
+// - SQUIZZLE_TEST_REPOSITORY env var (e.g., your-org/squizzle-test)
+// - Being logged in to the registry (docker login)
+
+describe('build command integration with real registry', () => {
+  let tempDir: string
+  let config: Config
+  let testVersion: string
+  
+  const registry = process.env.SQUIZZLE_TEST_REGISTRY
+  const repository = process.env.SQUIZZLE_TEST_REPOSITORY
+  
+  // Skip tests if registry not configured
+  const skipMessage = !registry || !repository 
+    ? 'Skipping: Set SQUIZZLE_TEST_REGISTRY and SQUIZZLE_TEST_REPOSITORY env vars'
+    : undefined
+    
+  beforeAll(async () => {
+    if (skipMessage) return
+    
+    // Create temp directory for test files
+    tempDir = await fs.mkdtemp(path.join(tmpdir(), 'squizzle-test-'))
+    
+    // Setup test project structure
+    await fs.mkdir(path.join(tempDir, 'db', 'drizzle'), { recursive: true })
+    await fs.mkdir(path.join(tempDir, 'db', 'tarballs'), { recursive: true })
+    await fs.mkdir(path.join(tempDir, '.squizzle', 'build'), { recursive: true })
+    
+    // Create test migration files
+    await fs.writeFile(
+      path.join(tempDir, 'db', 'drizzle', '0001_initial.sql'),
+      'CREATE TABLE users (id SERIAL PRIMARY KEY, email VARCHAR(255) UNIQUE NOT NULL);'
+    )
+    
+    await fs.writeFile(
+      path.join(tempDir, 'db', 'drizzle', '0002_add_created_at.sql'),
+      'ALTER TABLE users ADD COLUMN created_at TIMESTAMP DEFAULT NOW();'
+    )
+    
+    // Create package.json
+    await fs.writeFile(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({
+        name: 'squizzle-integration-test',
+        devDependencies: {
+          'drizzle-kit': '^0.20.0'
+        }
+      })
+    )
+    
+    // Setup config
+    config = {
+      version: '2.0',
+      storage: {
+        type: 'oci',
+        registry: registry!,
+        repository: repository!
+      },
+      environments: {
+        development: {
+          database: {
+            host: 'localhost',
+            port: 5432,
+            database: 'test',
+            user: 'test',
+            password: 'test'
+          }
+        }
+      }
+    }
+    
+    // Generate unique test version
+    testVersion = `99.99.${Date.now()}`
+  })
+  
+  afterAll(async () => {
+    if (skipMessage) return
+    
+    // Cleanup: Delete test version from registry
+    if (testVersion) {
+      try {
+        const storage = createOCIStorage(config.storage as any)
+        await storage.delete(testVersion)
+      } catch (error) {
+        // Ignore cleanup errors
+      }
+    }
+    
+    // Remove temp directory
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true })
+    }
+  })
+  
+  beforeEach(() => {
+    if (skipMessage) return
+    
+    // Mock process.cwd for the build command
+    const originalCwd = process.cwd
+    process.cwd = () => tempDir
+    
+    // Restore after test
+    return () => {
+      process.cwd = originalCwd
+    }
+  })
+  
+  it.skipIf(skipMessage)('should build and push artifact to real registry', async () => {
+    const options = {
+      notes: 'Integration test with real registry',
+      author: 'test-suite',
+      config
+    }
+    
+    // Mock execSync to avoid running actual drizzle-kit
+    const originalExecSync = execSync
+    ;(global as any).execSync = () => Buffer.from('')
+    
+    try {
+      // Build and push
+      await buildCommand(testVersion, options)
+      
+      // Verify artifact was pushed by checking it exists
+      const storage = createOCIStorage(config.storage as any)
+      const exists = await storage.exists(testVersion)
+      expect(exists).toBe(true)
+      
+      // Verify we can retrieve the manifest
+      const manifest = await storage.getManifest(testVersion)
+      expect(manifest.version).toBe(testVersion)
+      expect(manifest.notes).toBe('Integration test with real registry')
+      expect(manifest.author).toBe('test-suite')
+      expect(manifest.files).toHaveLength(2)
+      
+      // Verify tarball was created locally
+      const tarballPath = path.join(tempDir, 'db', 'tarballs', `squizzle-v${testVersion}.tar.gz`)
+      const tarballExists = await fs.access(tarballPath).then(() => true).catch(() => false)
+      expect(tarballExists).toBe(true)
+    } finally {
+      ;(global as any).execSync = originalExecSync
+    }
+  })
+  
+  it.skipIf(skipMessage)('should skip push with --skip-push flag', async () => {
+    const localVersion = `99.98.${Date.now()}`
+    const options = {
+      notes: 'Skip push test',
+      config,
+      skipPush: true
+    }
+    
+    // Mock execSync
+    const originalExecSync = execSync
+    ;(global as any).execSync = () => Buffer.from('')
+    
+    try {
+      await buildCommand(localVersion, options)
+      
+      // Verify tarball was created locally
+      const tarballPath = path.join(tempDir, 'db', 'tarballs', `squizzle-v${localVersion}.tar.gz`)
+      const tarballExists = await fs.access(tarballPath).then(() => true).catch(() => false)
+      expect(tarballExists).toBe(true)
+      
+      // Verify it was NOT pushed to registry
+      const storage = createOCIStorage(config.storage as any)
+      const exists = await storage.exists(localVersion)
+      expect(exists).toBe(false)
+    } finally {
+      ;(global as any).execSync = originalExecSync
+    }
+  })
+  
+  it.skipIf(skipMessage)('should use environment variable overrides', async () => {
+    // Set different registry/repo via env vars
+    process.env.SQUIZZLE_REGISTRY = registry
+    process.env.SQUIZZLE_REPOSITORY = repository
+    
+    const envVersion = `99.97.${Date.now()}`
+    const options = {
+      notes: 'Environment override test',
+      config: {
+        ...config,
+        storage: {
+          ...config.storage,
+          registry: 'wrong-registry.com',
+          repository: 'wrong/repo'
+        }
+      }
+    }
+    
+    // Mock execSync
+    const originalExecSync = execSync
+    ;(global as any).execSync = () => Buffer.from('')
+    
+    try {
+      await buildCommand(envVersion, options)
+      
+      // Verify it was pushed to the env var registry, not the config one
+      const storage = createOCIStorage({
+        type: 'oci',
+        registry: registry!,
+        repository: repository!
+      } as any)
+      const exists = await storage.exists(envVersion)
+      expect(exists).toBe(true)
+      
+      // Cleanup
+      await storage.delete(envVersion)
+    } finally {
+      ;(global as any).execSync = originalExecSync
+      delete process.env.SQUIZZLE_REGISTRY
+      delete process.env.SQUIZZLE_REPOSITORY
+    }
+  })
+  
+  it.skipIf(skipMessage)('should verify push and retrieve manifest after upload', async () => {
+    const verifyVersion = `99.96.${Date.now()}`
+    const options = {
+      notes: 'Verification test',
+      author: 'integration-test',
+      config
+    }
+    
+    // Mock execSync
+    const originalExecSync = execSync
+    ;(global as any).execSync = () => Buffer.from('')
+    
+    // Spy on console.warn to ensure no warnings
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    
+    try {
+      await buildCommand(verifyVersion, options)
+      
+      // Should not have any warnings
+      expect(consoleWarn).not.toHaveBeenCalled()
+      
+      // Manually verify the push
+      const storage = createOCIStorage(config.storage as any)
+      const exists = await storage.exists(verifyVersion)
+      expect(exists).toBe(true)
+      
+      const manifest = await storage.getManifest(verifyVersion)
+      expect(manifest.version).toBe(verifyVersion)
+      
+      // Cleanup
+      await storage.delete(verifyVersion)
+    } finally {
+      ;(global as any).execSync = originalExecSync
+      consoleWarn.mockRestore()
+    }
+  })
+  
+  it.skipIf(skipMessage)('should list versions including newly pushed one', async () => {
+    const listVersion = `99.95.${Date.now()}`
+    const options = {
+      notes: 'List test',
+      config
+    }
+    
+    // Mock execSync
+    const originalExecSync = execSync
+    ;(global as any).execSync = () => Buffer.from('')
+    
+    try {
+      // Get list before push
+      const storage = createOCIStorage(config.storage as any)
+      const versionsBefore = await storage.list()
+      
+      // Build and push
+      await buildCommand(listVersion, options)
+      
+      // Get list after push
+      const versionsAfter = await storage.list()
+      
+      // Should have one more version
+      expect(versionsAfter.length).toBe(versionsBefore.length + 1)
+      expect(versionsAfter).toContain(listVersion)
+      
+      // Cleanup
+      await storage.delete(listVersion)
+    } finally {
+      ;(global as any).execSync = originalExecSync
+    }
+  })
+})

--- a/packages/squizzle-cli/src/commands/build.test.ts
+++ b/packages/squizzle-cli/src/commands/build.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { pushToStorage, verifyPush } from './build'
+import { StorageError } from '@squizzle/core'
+import { createOCIStorage } from '@squizzle/oci'
+import ora from 'ora'
+
+// Mock dependencies
+vi.mock('@squizzle/oci', () => ({
+  createOCIStorage: vi.fn()
+}))
+
+describe('build command storage integration', () => {
+  let mockStorage: any
+  let mockPush: any
+  let mockExists: any
+  let mockGetManifest: any
+  let mockSpinner: any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    
+    // Setup mock storage
+    mockPush = vi.fn().mockResolvedValue('ghcr.io/test/repo:v1.0.0')
+    mockExists = vi.fn().mockResolvedValue(true)
+    mockGetManifest = vi.fn().mockResolvedValue({ version: '1.0.0' })
+    
+    mockStorage = {
+      push: mockPush,
+      exists: mockExists,
+      getManifest: mockGetManifest
+    }
+
+    vi.mocked(createOCIStorage).mockReturnValue(mockStorage)
+
+    // Mock spinner
+    mockSpinner = {
+      start: vi.fn().mockReturnThis(),
+      succeed: vi.fn().mockReturnThis(),
+      fail: vi.fn().mockReturnThis(),
+      text: ''
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.SQUIZZLE_REGISTRY
+    delete process.env.SQUIZZLE_REPOSITORY
+  })
+
+  describe('pushToStorage', () => {
+    it('should push artifact with correct parameters', async () => {
+      const options = {
+        config: {
+          storage: {
+            type: 'oci',
+            registry: 'ghcr.io',
+            repository: 'test/repo'
+          }
+        }
+      }
+      
+      const buffer = Buffer.from('test content')
+      const manifest = { version: '1.0.0', checksum: 'abc123' }
+      
+      const url = await pushToStorage('1.0.0', buffer, manifest, options, mockSpinner)
+      
+      expect(mockPush).toHaveBeenCalledWith('1.0.0', buffer, manifest)
+      expect(url).toBe('ghcr.io/test/repo:v1.0.0')
+    })
+
+    it('should use registry override from options', async () => {
+      const options = {
+        registry: 'docker.io',
+        repository: 'myorg/myrepo',
+        config: {
+          storage: {
+            type: 'oci',
+            registry: 'ghcr.io',
+            repository: 'test/repo'
+          }
+        }
+      }
+      
+      const buffer = Buffer.from('test content')
+      const manifest = { version: '1.0.0', checksum: 'abc123' }
+      
+      await pushToStorage('1.0.0', buffer, manifest, options, mockSpinner)
+      
+      expect(createOCIStorage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          registry: 'docker.io',
+          repository: 'myorg/myrepo'
+        })
+      )
+    })
+
+    it('should use environment variables for config', async () => {
+      process.env.SQUIZZLE_REGISTRY = 'env-registry.io'
+      process.env.SQUIZZLE_REPOSITORY = 'env/repo'
+      
+      const options = {
+        config: {
+          storage: {
+            type: 'oci',
+            registry: 'ghcr.io',
+            repository: 'test/repo'
+          }
+        }
+      }
+      
+      const buffer = Buffer.from('test content')
+      const manifest = { version: '1.0.0', checksum: 'abc123' }
+      
+      await pushToStorage('1.0.0', buffer, manifest, options, mockSpinner)
+      
+      expect(createOCIStorage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          registry: 'env-registry.io',
+          repository: 'env/repo'
+        })
+      )
+    })
+
+    it('should report upload speed', async () => {
+      const options = {
+        config: {
+          storage: {
+            type: 'oci',
+            registry: 'ghcr.io',
+            repository: 'test/repo'
+          }
+        }
+      }
+      
+      const buffer = Buffer.alloc(10 * 1024 * 1024) // 10MB
+      const manifest = { version: '1.0.0', checksum: 'abc123' }
+      
+      // Mock push to take some time
+      mockPush.mockImplementation(() => {
+        return new Promise(resolve => setTimeout(() => resolve('ghcr.io/test/repo:v1.0.0'), 100))
+      })
+      
+      await pushToStorage('1.0.0', buffer, manifest, options, mockSpinner)
+      
+      expect(mockSpinner.text).toContain('Pushed')
+      expect(mockSpinner.text).toContain('MB')
+    })
+
+    it('should handle authentication errors with helpful message', async () => {
+      mockPush.mockRejectedValue(new StorageError('401 Unauthorized'))
+      
+      const options = {
+        config: {
+          storage: {
+            type: 'oci',
+            registry: 'ghcr.io',
+            repository: 'test/repo'
+          }
+        }
+      }
+      
+      const buffer = Buffer.from('test content')
+      const manifest = { version: '1.0.0', checksum: 'abc123' }
+      
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      
+      await expect(pushToStorage('1.0.0', buffer, manifest, options, mockSpinner))
+        .rejects.toThrow(StorageError)
+      
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Authentication failed')
+      )
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining('docker login')
+      )
+      
+      consoleError.mockRestore()
+    })
+
+    it('should handle network errors with helpful message', async () => {
+      mockPush.mockRejectedValue(new StorageError('Network timeout'))
+      
+      const options = {
+        config: {
+          storage: {
+            type: 'oci',
+            registry: 'ghcr.io',
+            repository: 'test/repo'
+          }
+        }
+      }
+      
+      const buffer = Buffer.from('test content')
+      const manifest = { version: '1.0.0', checksum: 'abc123' }
+      
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      
+      await expect(pushToStorage('1.0.0', buffer, manifest, options, mockSpinner))
+        .rejects.toThrow(StorageError)
+      
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Network error')
+      )
+      
+      consoleError.mockRestore()
+    })
+
+    it('should handle repository not found errors', async () => {
+      mockPush.mockRejectedValue(new StorageError('404 Not Found'))
+      
+      const options = {
+        config: {
+          storage: {
+            type: 'oci',
+            registry: 'ghcr.io',
+            repository: 'test/repo'
+          }
+        }
+      }
+      
+      const buffer = Buffer.from('test content')
+      const manifest = { version: '1.0.0', checksum: 'abc123' }
+      
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      
+      await expect(pushToStorage('1.0.0', buffer, manifest, options, mockSpinner))
+        .rejects.toThrow(StorageError)
+      
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Repository not found')
+      )
+      
+      consoleError.mockRestore()
+    })
+  })
+
+  describe('verifyPush', () => {
+    it('should verify artifact exists after push', async () => {
+      const options = {
+        config: {
+          storage: {
+            type: 'oci',
+            registry: 'ghcr.io',
+            repository: 'test/repo'
+          }
+        }
+      }
+      
+      await verifyPush('1.0.0', 1024, options, mockSpinner)
+      
+      expect(mockExists).toHaveBeenCalledWith('1.0.0')
+      expect(mockGetManifest).toHaveBeenCalledWith('1.0.0')
+    })
+
+    it('should warn if verification fails but not throw', async () => {
+      mockExists.mockResolvedValue(false)
+      
+      const options = {
+        config: {
+          storage: {
+            type: 'oci',
+            registry: 'ghcr.io',
+            repository: 'test/repo'
+          }
+        }
+      }
+      
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      // Should not throw
+      await verifyPush('1.0.0', 1024, options, mockSpinner)
+      
+      expect(consoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining('Warning'),
+        expect.any(String)
+      )
+      
+      consoleWarn.mockRestore()
+    })
+
+    it('should warn if manifest version differs', async () => {
+      mockGetManifest.mockResolvedValue({ version: '2.0.0' })
+      
+      const options = {
+        config: {
+          storage: {
+            type: 'oci',
+            registry: 'ghcr.io',
+            repository: 'test/repo'
+          }
+        }
+      }
+      
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      await verifyPush('1.0.0', 1024, options, mockSpinner)
+      
+      expect(consoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining('Warning: Stored version')
+      )
+      
+      consoleWarn.mockRestore()
+    })
+
+    it('should use overridden storage config', async () => {
+      const options = {
+        registry: 'docker.io',
+        repository: 'myorg/myrepo',
+        config: {
+          storage: {
+            type: 'oci',
+            registry: 'ghcr.io',
+            repository: 'test/repo'
+          }
+        }
+      }
+      
+      await verifyPush('1.0.0', 1024, options, mockSpinner)
+      
+      expect(createOCIStorage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          registry: 'docker.io',
+          repository: 'myorg/myrepo'
+        })
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Implements storage push functionality for the CLI build command
- Adds flexible configuration options via CLI flags and environment variables
- Includes comprehensive error handling and user-friendly messages

## Changes
- ✅ Add --registry and --repository CLI options to override storage config
- ✅ Add --skip-push flag for local-only builds
- ✅ Support SQUIZZLE_REGISTRY and SQUIZZLE_REPOSITORY environment variables
- ✅ Implement push progress reporting with upload speed calculation  
- ✅ Add push verification after successful upload
- ✅ Provide helpful error messages for common failures (auth, network, 404)
- ✅ Export pushToStorage and verifyPush functions for testing
- ✅ Add comprehensive unit tests (11 tests, 100% passing)
- ✅ Add integration tests with real registry support
- ✅ Update CLI documentation with detailed storage configuration info

## Test Results
```
✓ src/commands/build.test.ts (11 tests) 
✓ All unit tests passing
✓ Integration tests ready (require registry setup)
```

## Task Completion
This PR completes **Wave 2 Task #4: CLI Build Command Push to Storage** from the Strike Team Alpha mission.

## Next Steps
- Charlie team can now use the storage push functionality
- Delta team can integrate with the build command for CI/CD workflows

🤖 Generated with [Claude Code](https://claude.ai/code)